### PR TITLE
fix: enforce LF line endings to fix lint failures on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,6 @@
   "trailingComma": "es5",
   "bracketSpacing": true,
   "bracketSameLine": false,
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
 }

--- a/src/components/WorkExperience.tsx
+++ b/src/components/WorkExperience.tsx
@@ -26,7 +26,7 @@ export const WorkExperience: FC<WorkExperienceProps> = ({ work }) => {
   // Group contiguous roles by company name (assuming work is reverse chronological).
   // Each group gets a wrapper with a single GrowthIndicator summarizing progression.
   const groups: { company: string; items: Work[] }[] = [];
-  work.forEach((item) => {
+  work.forEach(item => {
     const company = item.name || '';
     const lastGroup = groups[groups.length - 1];
     if (lastGroup && lastGroup.company === company) {
@@ -74,9 +74,19 @@ export const WorkExperience: FC<WorkExperienceProps> = ({ work }) => {
         const showHeader = totalRoles > 1;
 
         return (
-          <div key={`group-${gi}`} className={showHeader ? 'pl-3 border-l-2 border-brand mb-4 print:mb-2' : 'mb-4 print:mb-2'}>
+          <div
+            key={`group-${gi}`}
+            className={
+              showHeader ? 'pl-3 border-l-2 border-brand mb-4 print:mb-2' : 'mb-4 print:mb-2'
+            }
+          >
             {showHeader && (
-              <GroupHeader company={group.company} start={earliestStart} end={latestEnd} roles={totalRoles} />
+              <GroupHeader
+                company={group.company}
+                start={earliestStart}
+                end={latestEnd}
+                roles={totalRoles}
+              />
             )}
             {group.items.map((workItem, wi) => (
               <TimelineEntry

--- a/src/components/ui/GrowthIndicator.tsx
+++ b/src/components/ui/GrowthIndicator.tsx
@@ -18,7 +18,8 @@ export const GrowthIndicator: FC<GrowthIndicatorProps> = ({
   className,
   ariaLabel,
 }) => {
-  const clampedPercent = typeof percent === 'number' ? Math.max(0, Math.min(100, percent)) : undefined;
+  const clampedPercent =
+    typeof percent === 'number' ? Math.max(0, Math.min(100, percent)) : undefined;
   const clampedLevel = typeof level === 'number' ? Math.max(1, Math.min(5, level)) : undefined;
 
   return (
@@ -34,13 +35,15 @@ export const GrowthIndicator: FC<GrowthIndicatorProps> = ({
       aria-label={ariaLabel || label}
     >
       {/* Simple arrow glyph, avoids extra icon deps in tests */}
-      <span aria-hidden="true" className="font-bold leading-none">↑</span>
+      <span aria-hidden="true" className="font-bold leading-none">
+        ↑
+      </span>
       <span className="leading-none">{label}</span>
 
       {/* Optional tiny level dots (1-5) */}
       {typeof clampedLevel === 'number' && (
         <span className="ml-1 flex items-center gap-0.5" aria-hidden="true">
-          {[0, 1, 2, 3, 4].map((i) => (
+          {[0, 1, 2, 3, 4].map(i => (
             <span
               key={i}
               className={cn(
@@ -54,11 +57,11 @@ export const GrowthIndicator: FC<GrowthIndicatorProps> = ({
 
       {/* Optional tiny progress bar */}
       {typeof clampedPercent === 'number' && (
-        <span className="ml-1 inline-flex items-center w-12 h-1.5 rounded-full bg-brand/10 overflow-hidden" aria-hidden="true">
-          <span
-            className="h-full bg-brand"
-            style={{ width: `${clampedPercent}%` }}
-          />
+        <span
+          className="ml-1 inline-flex items-center w-12 h-1.5 rounded-full bg-brand/10 overflow-hidden"
+          aria-hidden="true"
+        >
+          <span className="h-full bg-brand" style={{ width: `${clampedPercent}%` }} />
         </span>
       )}
     </span>

--- a/src/components/ui/SectionCard.tsx
+++ b/src/components/ui/SectionCard.tsx
@@ -68,7 +68,9 @@ export const SectionCard: FC<SectionCardProps> = memo(
         <div className={`flex flex-col ${spacing.card.gap.default} ${spacing.card.gap.print}`}>
           {title && (
             <div className="flex items-start justify-between gap-2">
-              <h3 id={titleId} className={`${typography.weight.medium} ${typography.size.base} flex-1`}
+              <h3
+                id={titleId}
+                className={`${typography.weight.medium} ${typography.size.base} flex-1`}
               >
                 {title}
                 {subtitle && (


### PR DESCRIPTION
## Summary
- Add `.gitattributes` with `* text=auto eol=lf` to enforce LF line endings in the repository regardless of OS
- Set `"endOfLine": "lf"` in `.prettierrc` to make Prettier explicitly require LF
- Convert all existing files from CRLF to LF via `eslint --fix`

## Context
`npm run lint` was failing on Windows because `git config core.autocrlf=true` checks out files with CRLF line endings, but Prettier defaults to expecting LF. This caused every file to report `Delete ␍` errors.

## Test plan
- [ ] Verify `npm run lint` passes
- [ ] Verify `npm run build` succeeds
- [ ] Verify tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)